### PR TITLE
http_client: opt-in trust_invalid_certs flag

### DIFF
--- a/tor/src/http_client.rs
+++ b/tor/src/http_client.rs
@@ -35,6 +35,12 @@ pub struct HttpRequestParams {
     pub headers: Option<HashMap<String, String>>,
     pub body: Option<String>,
     pub timeout_ms: Option<u64>,
+    /// When `Some(true)`, accept self-signed or otherwise invalid TLS
+    /// certificates. Defaults to `false`. Intended for use cases like
+    /// Tor v3 hidden services, where the `.onion` address already
+    /// authenticates the endpoint and the upstream host typically
+    /// presents a self-signed cert (e.g. LND REST).
+    pub trust_invalid_certs: Option<bool>,
 }
 
 fn build_socks_proxy_url(socks_proxy: &str) -> String {
@@ -47,12 +53,18 @@ pub async fn make_http_request_async(
     socks_proxy: String,
 ) -> Result<HttpResponse, TorErrors> {
     // Create client with proxy
-    let client = Client::builder()
+    let mut builder = Client::builder()
         .proxy(
             Proxy::all(build_socks_proxy_url(&socks_proxy))
                 .map_err(|e| TorErrors::TcpStreamError(format!("Failed to create proxy: {}", e)))?,
         )
-        .timeout(Duration::from_millis(params.timeout_ms.unwrap_or(30000)))
+        .timeout(Duration::from_millis(params.timeout_ms.unwrap_or(30000)));
+
+    if params.trust_invalid_certs.unwrap_or(false) {
+        builder = builder.danger_accept_invalid_certs(true);
+    }
+
+    let client = builder
         .build()
         .map_err(|e| TorErrors::TcpStreamError(format!("Failed to create client: {}", e)))?;
 


### PR DESCRIPTION
## Summary

Adds an opt-in `trust_invalid_certs: Option<bool>` field to `HttpRequestParams`. When `Some(true)`, the underlying `reqwest::Client::builder()` is configured with `.danger_accept_invalid_certs(true)`. Defaults to `None`/`false`, so existing callers are unaffected.

## Motivation

The primary use case is Tor v3 hidden service traffic to endpoints that legitimately present self-signed certificates, for example: an LND node's REST API behind an `.onion` address. In that setup:

- The `.onion` address itself authenticates the endpoint cryptographically at the Tor layer.
- The TLS hostname can never match the `.onion` address.
- The upstream daemon (LND, CLN, etc.) ships with a self-signed certificate by default; demanding a public CA chain there is a category error.

Without a knob to disable cert validation, downstream apps (Zeus and others using `react-native-nitro-tor` 0.5.x, which depends on this crate) cannot connect to their users' own Lightning nodes over Tor. We hit this in [ZeusLN/zeus#4178](https://github.com/ZeusLN/zeus/issues/4178) after upgrading off the previous Tor client.

## Changes

`tor/src/http_client.rs`:
- New `trust_invalid_certs: Option<bool>` field on `HttpRequestParams` (Serde-derived, so deserialization remains source-compatible with callers that don't set it).
- `make_http_request_async` now conditionally applies `.danger_accept_invalid_certs(true)` on the `reqwest::Client::builder()` when the field is `Some(true)`.

## Test plan

- [x] `cargo check -p tor` clean against `master` baseline.
- [x] Field defaults to `false` so existing callsites in `tor-ffi` and downstream consumers continue to perform strict TLS validation.
- [ ] Wired through to a downstream React Native fork to confirm Zeus can connect to an LND REST node over Tor with a self-signed cert.